### PR TITLE
fix crawler

### DIFF
--- a/app/crawler/includes/ChatStorage.hpp
+++ b/app/crawler/includes/ChatStorage.hpp
@@ -14,4 +14,5 @@ public:
 public:
 	void add(const std::string &channel, const std::string &content);
 	void insert_to_db(sql::Statement *_stmt);
+	void clear();
 };

--- a/app/crawler/srcs/ChatStorage.cpp
+++ b/app/crawler/srcs/ChatStorage.cpp
@@ -40,3 +40,7 @@ void ChatStorage::insert_to_db(sql::Statement *stmt) {
 	// std::cout << query << std::endl;
 	this->_chat_storage.clear();
 }
+
+void ChatStorage::clear() {
+	this->_chat_storage.clear();
+}

--- a/app/crawler/srcs/IrcClient.cpp
+++ b/app/crawler/srcs/IrcClient.cpp
@@ -294,5 +294,6 @@ void	IrcClient::parse_chat(const std::string &msg, bool log)
 	{
 		std::cerr << "[-] ";
 		std::cerr << e.what() << std::endl;
+		this->_chat_storage.clear();
 	}
 }


### PR DESCRIPTION
chatlog에 이상한 이스케이프 문자가 들어오면, 무한루프 도는 버그 수정